### PR TITLE
fix: cryto API is now imported with node namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BinaryToTextEncoding, webcrypto } from "crypto";
+import { BinaryToTextEncoding, webcrypto } from "node:crypto";
 import isPlainObject from "./isPlainObject";
 import { encoders } from "./encoders";
 


### PR DESCRIPTION
This fix the use of this library in Cloudflare workers

#1 