### PR TITLE
refactor: replace base-64 dependency with native Node.js API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,7 @@
       "name": "deterministic-object-hash",
       "version": "2.0.2",
       "license": "MIT",
-      "dependencies": {
-        "base-64": "^1.0.0"
-      },
       "devDependencies": {
-        "@types/base-64": "^1.0.2",
         "@types/jest": "^27.4.0",
         "@types/lodash": "^4.14.178",
         "@types/node": "18.18.9",
@@ -1023,12 +1019,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/base-64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
-      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
-      "dev": true
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1339,11 +1329,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4873,12 +4858,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/base-64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
-      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
-      "dev": true
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -5134,11 +5113,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/zbauman3/Deterministic-Object-Hash#readme",
   "devDependencies": {
-    "@types/base-64": "^1.0.2",
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.178",
     "@types/node": "18.18.9",
@@ -37,6 +36,5 @@
     "node": ">=18"
   },
   "dependencies": {
-    "base-64": "^1.0.0"
   }
 }

--- a/src/encoders.ts
+++ b/src/encoders.ts
@@ -1,5 +1,3 @@
-import { encode as btoa } from "base-64";
-
 const binary = (input: ArrayBuffer) => {
   let binary = "";
   const bytes = new Uint8Array(input);
@@ -18,9 +16,7 @@ const hex = (input: ArrayBuffer) =>
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 
-// @see https://stackoverflow.com/questions/35155089/node-sha-256-base64-digest
-// @see https://stackoverflow.com/questions/9267899/arraybuffer-to-base64-encoded-string
-const base64 = (input: ArrayBuffer) => btoa(binary(input));
+const base64 = (input: ArrayBuffer) => Buffer.from(input).toString('base64');
 
 const base64url = (input: ArrayBuffer) =>
   base64(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");


### PR DESCRIPTION
Replaced the `base-64` package with `Buffer.from(arrayBuffer).toString('base64')`, which is built
into Node.js core and requires no external dependency.
